### PR TITLE
fix: correct default OpenAI API URL in ProjectTestMojo.java to preven…

### DIFF
--- a/src/main/java/zju/cst/aces/ProjectTestMojo.java
+++ b/src/main/java/zju/cst/aces/ProjectTestMojo.java
@@ -78,7 +78,7 @@ public class ProjectTestMojo
     public File promptPath;
     @Parameter(property = "examplePath", defaultValue = "${project.basedir}/exampleUsage.json")
     public File examplePath;
-    @Parameter(property = "url", defaultValue = "https://api.gptsapi.net/v1/chat/completions")
+    @Parameter(property = "url", defaultValue = "https://api.openai.com/v1/chat/completions")
     public String url;
     @Parameter(property = "model", defaultValue = "gpt-3.5-turbo")
     public String model;


### PR DESCRIPTION
Hi, thanks for creating and maintaining such a practical and useful project with well-written documentation :)

In `src/main/java/zju/cst/aces/ProjectTestMojo.java` line 81, the @Parameter currently uses
```Java
defaultValue = "https://api.gptsapi.net/v1/chat/completions"
```
According to the [README](https://github.com/ZJU-ACES-ISE/chatunitest-maven-plugin/blob/main/README.md), the correct default should be `https://api.openai.com/v1/chat/completions`
The current value results in a 404 error.