### PR TITLE
feat: support -Dmodule parameter to skip non-target modules

### DIFF
--- a/src/main/java/zju/cst/aces/ClassTestMojo.java
+++ b/src/main/java/zju/cst/aces/ClassTestMojo.java
@@ -42,6 +42,7 @@ public class ClassTestMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         String className = selectClass;
 
         try {

--- a/src/main/java/zju/cst/aces/CleanMojo.java
+++ b/src/main/java/zju/cst/aces/CleanMojo.java
@@ -36,6 +36,7 @@ public class CleanMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         log.info("\n==========================\n[ChatUniTest] Cleaning project " +  project.getBasedir().getName() + " ...");
         log.info("\n==========================\n[ChatUniTest] Cleaning output directory "
                 + config.getTmpOutput() + " and " + config.getTestOutput() + " ...");

--- a/src/main/java/zju/cst/aces/CopyTestMojo.java
+++ b/src/main/java/zju/cst/aces/CopyTestMojo.java
@@ -35,6 +35,7 @@ public class CopyTestMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         try {
             log.info("\n==========================\n[ChatUniTest] Copying tests ...");
             TestCompiler compiler = new TestCompiler(config.getTestOutput(), config.getCompileOutputPath(),

--- a/src/main/java/zju/cst/aces/DebugMojo.java
+++ b/src/main/java/zju/cst/aces/DebugMojo.java
@@ -37,6 +37,7 @@ public class DebugMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         try {
             log.info("\n==========================\n[ChatUniTest] Debugging tests ...");
             config.getValidator().execute(fullTestName);

--- a/src/main/java/zju/cst/aces/MethodTestMojo.java
+++ b/src/main/java/zju/cst/aces/MethodTestMojo.java
@@ -42,6 +42,7 @@ public class MethodTestMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         String className = selectMethod.split("#")[0];
         String methodName = selectMethod.split("#")[1];
 

--- a/src/main/java/zju/cst/aces/MethodTestWithoutOverloadMojo.java
+++ b/src/main/java/zju/cst/aces/MethodTestWithoutOverloadMojo.java
@@ -44,6 +44,14 @@ public class MethodTestWithoutOverloadMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
+        // warn if aggregator and no module
+        if ("pom".equals(project.getPackaging()) && (module == null || module.isEmpty())) {
+            log.warn("[ChatUniTest] You are running on an aggregator POM. " +
+                    "Specify -Dmodule=<submodule> or use -pl/-f to target a submodule.");
+            return;
+        }
+
         String className = selectMethod.split("#")[0];
         String methodName = selectMethod.split("#")[1];
         String signature = simplifyMethodCall(selectMethod);

--- a/src/main/java/zju/cst/aces/ParseMojo.java
+++ b/src/main/java/zju/cst/aces/ParseMojo.java
@@ -35,6 +35,7 @@ public class ParseMojo extends ProjectTestMojo {
     public void execute() throws MojoExecutionException {
         log = getLog();
         init();
+        if (shouldSkip()) return;
         PhaseImpl.createPhase(config).prepare();
     }
 }

--- a/src/main/java/zju/cst/aces/ProjectTestMojo.java
+++ b/src/main/java/zju/cst/aces/ProjectTestMojo.java
@@ -45,12 +45,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
@@ -132,11 +127,14 @@ public class ProjectTestMojo
     public String mavenHome;
     @Parameter(property = "sampleSize", defaultValue = "10")
     public int sampleSize;
+    @Parameter(property = "module", defaultValue = "")
+    public String module;
     public static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     @Component(hint = "default")
     public DependencyGraphBuilder dependencyGraphBuilder;
     public static Log log;
     public Config config;
+    protected boolean skipThisModule = false;
 
 
     /**
@@ -145,6 +143,7 @@ public class ProjectTestMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         log.info(String.format("\n==========================\n[%s] Generating tests for project %s ...", phaseType, project.getBasedir().getName()));
         log.warn(String.format("[%s] It may consume a significant number of tokens!", phaseType));
 
@@ -177,6 +176,7 @@ public class ProjectTestMojo
 //                log.info("SmartUnitTest generation completed. Starting test generation...");
 //            }
 
+
             // Generate tests
             new Task(config, new RunnerImpl(config)).startProjectTask();
         } catch (Exception e) {
@@ -188,7 +188,42 @@ public class ProjectTestMojo
     public void init() {
         log = getLog();
         MavenLogger mLogger = new MavenLogger(log);
-        Project myProject = new ProjectImpl(project, listClassPaths(project, dependencyGraphBuilder));
+        // 1) Resolve target MavenProject:
+        MavenProject targetProject = project;
+        if (module != null && !module.isEmpty()) {
+            targetProject = resolveModule(module, session.getProjects());
+            if (targetProject == null) {
+                log.error("[ChatUniTest] Cannot resolve module: " + module);
+                skipThisModule = true;
+                return;
+            }
+
+            boolean isSameModule =
+                    Objects.equals(project.getBasedir(), targetProject.getBasedir());
+
+            if (!isSameModule) {
+                skipThisModule = true;
+                return; // ← quit
+            }
+            log.info("[ChatUniTest] Using module: "
+                    + targetProject.getGroupId() + ":" + targetProject.getArtifactId());
+        }
+        else{
+            log.info("[ChatUniTest] Using current project: "
+                    + project.getGroupId() + ":" + project.getArtifactId());
+        }
+
+        // 2) Build Project/Config with the resolved target module (the rest logic is unchanged)
+        Project myProject = new ProjectImpl(targetProject, listClassPaths(targetProject, dependencyGraphBuilder));
+
+        // If current project is an aggregator POM and no module is specified
+        if ("pom".equals(project.getPackaging()) && (module == null || module.isEmpty())) {
+            log.warn("[ChatUniTest] You are running on an aggregator POM. " +
+                    "Usually you need to specify -Dmodule=<submodule> or use -pl/-f to target a submodule.");
+            skipThisModule = true;
+            return; // exit early since we cannot generate tests directly on a POM
+        }
+
         config = new Config.ConfigBuilder(myProject)
                 .logger(mLogger)
                 .promptPath(promptPath)
@@ -221,6 +256,7 @@ public class ProjectTestMojo
                 .phaseType(phaseType)
                 .sampleSize(sampleSize)
                 .build();
+
         // SmartUnitTest generation is now handled in the execute method when phaseType is TELPA
         config.setPluginSign(phaseType);
         config.print();
@@ -371,6 +407,48 @@ public class ProjectTestMojo
             System.out.println(e);
         }
         return classPaths;
+    }
+
+    private MavenProject resolveModule(String key, List<MavenProject> all) {
+        // First support "groupId:artifactId"
+        for (MavenProject p : all) {
+            if ((p.getGroupId() + ":" + p.getArtifactId()).equals(key)) {
+                return p;
+            }
+        }
+        // Then support only artifactId (must be unique)
+        List<MavenProject> sameArtifact = new ArrayList<>();
+        for (MavenProject p : all) {
+            if (p.getArtifactId().equals(key)) sameArtifact.add(p);
+        }
+        if (sameArtifact.size() == 1) return sameArtifact.get(0);
+        if (sameArtifact.size() > 1) {
+            throw new RuntimeException(
+                    "[ChatUniTest] Ambiguous module '" + key + "'. Use groupId:artifactId to disambiguate.");
+        }
+
+        // Finally support resolving by relative/absolute path (directory where pom.xml is located)
+        File keyFile = new File(key);
+        if (keyFile.exists()) {
+            String keyAbs = keyFile.toPath().toAbsolutePath().normalize().toString();
+            for (MavenProject p : all) {
+                File pom = p.getFile(); // .../submodule/pom.xml
+                if (pom != null) {
+                    String dirAbs = pom.getParentFile().toPath().toAbsolutePath().normalize().toString();
+                    if (dirAbs.equals(keyAbs)) return p;
+                }
+            }
+        }
+
+        throw new RuntimeException("[ChatUniTest] Module '" + key + "' not found in reactor.");
+    }
+
+    protected boolean shouldSkip() {
+        if (skipThisModule) {
+            getLog().info("[ChatUniTest] Skipped by module selection / aggregator POM.");
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/zju/cst/aces/RestoreBackupMojo.java
+++ b/src/main/java/zju/cst/aces/RestoreBackupMojo.java
@@ -35,6 +35,7 @@ public class RestoreBackupMojo
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         try {
             log.info("\n==========================\n[ChatUniTest] Restoring test folder ...");
             TestCompiler compiler = new TestCompiler(config.getTestOutput(), config.getCompileOutputPath(),

--- a/src/main/java/zju/cst/aces/SampleMojo.java
+++ b/src/main/java/zju/cst/aces/SampleMojo.java
@@ -32,6 +32,7 @@ public class SampleMojo extends ProjectTestMojo {
      */
     public void execute() throws MojoExecutionException {
         init();
+        if (shouldSkip()) return;
         log = getLog();
         log.info("\n==========================\n[ChatUniTest] Generating sample data...");
         


### PR DESCRIPTION
Update Description

Added the ability to run test generation directly from the root of a multi-module project for a specified module. This can be done either by passing -Dmodule=<submodule> or by defining <module>...</module> entries in the project’s root POM.

Key changes:

If -Dmodule is provided, the plugin resolves the correct MavenProject from the reactor and only executes against that submodule.

All other modules (including the root aggregator POM) are automatically skipped to prevent duplicate or incorrect execution.

If no -Dmodule is specified and the current project is an aggregator POM, the plugin now logs a warning reminding users to provide -Dmodule or use Maven’s -pl/-f to target the intended module.

Benefit:
This update ensures the plugin no longer mistakenly runs on the wrong module (e.g., always defaulting to the first one) and gives users fine-grained control over which submodule ChatUniTest should run against.